### PR TITLE
Allow overriding of convertWebIntelligentPlainTextToHtml bits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='plone.intelligenttext',
       namespace_packages=['plone'],
       include_package_data=True,
       zip_safe=False,
+      test_suite="plone.intelligenttext.tests.test_suite",
       install_requires=[
         'setuptools',
       ],


### PR DESCRIPTION
This allows an easy way to extend the converter through subclassing.
One might want to override the regexps, or modify the HTML that one of
the replace\* methods produces.

Fully compatible with old API, all tests passing.
