### PR TITLE
Recognize URLs at the end of sentences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,10 @@ Changelog
 
 New:
 
-- *add item here*
+- Recognizes URLs embedded at the end of sentences.
+  The punctuation mark of the sentence is split from the URL.
+  Use brackets to force punctuation marks at the end of URLs.
+  [tarnap]
 
 Fixes:
 

--- a/plone/intelligenttext/README.rst
+++ b/plone/intelligenttext/README.rst
@@ -145,6 +145,60 @@ https is accepted::
     >>> bprint(convertWebIntelligentPlainTextToHtml("https://localhost"))
     <a href="https://localhost" rel="nofollow">https://localhost</a>
 
+URLs at the end of sentences are recognized::
+
+    >>> sentence = "Go to http://some.webpa.ge."
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Go to <a href="http://some.webpa.ge" rel="nofollow">http://some.webpa.ge</a>.
+    >>> sentence = "Visit http://some.webpa.ge?"
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Visit <a href="http://some.webpa.ge" rel="nofollow">http://some.webpa.ge</a>?
+    >>> sentence = "Follow http://some.webpa.ge!"
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Follow <a href="http://some.webpa.ge" rel="nofollow">http://some.webpa.ge</a>!
+
+URLs with trailing slashes at the end of sentences are recognized::
+
+    >>> sentence = "Go to http://some.webpa.ge/."
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Go to <a href="http://some.webpa.ge/" rel="nofollow">http://some.webpa.ge/</a>.
+    >>> sentence = "Visit http://some.webpa.ge/?"
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Visit <a href="http://some.webpa.ge/" rel="nofollow">http://some.webpa.ge/</a>?
+    >>> sentence = "Follow http://some.webpa.ge/!"
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Follow <a href="http://some.webpa.ge/" rel="nofollow">http://some.webpa.ge/</a>!
+
+URLs with GET arguments at the end of sentences are recognized::
+
+    >>> sentence = "Go to http://some.webpa.ge/with/?get=arguments."
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Go to <a href="http://some.webpa.ge/with/?get=arguments" rel="nofollow">http://some.webpa.ge/with/?get=arguments</a>.
+    >>> sentence = "Visit http://some.webpa.ge/with/?get=arguments?"
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Visit <a href="http://some.webpa.ge/with/?get=arguments" rel="nofollow">http://some.webpa.ge/with/?get=arguments</a>?
+    >>> sentence = "Follow http://some.webpa.ge/with/?get=arguments!"
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Follow <a href="http://some.webpa.ge/with/?get=arguments" rel="nofollow">http://some.webpa.ge/with/?get=arguments</a>!
+
+URLs with named anchors at the end of sentences are recognized::
+
+    >>> sentence = "Go to http://some.webpa.ge/with/named/#anchors."
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Go to <a href="http://some.webpa.ge/with/named/#anchors" rel="nofollow">http://some.webpa.ge/with/named/#anchors</a>.
+    >>> sentence = "Visit http://some.webpa.ge/with/named/#anchors?"
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Visit <a href="http://some.webpa.ge/with/named/#anchors" rel="nofollow">http://some.webpa.ge/with/named/#anchors</a>?
+    >>> sentence = "Follow http://some.webpa.ge/with/named/#anchors!"
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Follow <a href="http://some.webpa.ge/with/named/#anchors" rel="nofollow">http://some.webpa.ge/with/named/#anchors</a>!
+
+You can put URLs in brackets to explicitly add punctuation marks to it::
+
+    >>> sentence = "Go to <http://some.webpa.ge/with/named/#anchors.>"
+    >>> bprint(convertWebIntelligentPlainTextToHtml(sentence))
+    Go to &lt;<a href="http://some.webpa.ge/with/named/#anchors." rel="nofollow">http://some.webpa.ge/with/named/#anchors.</a>&gt;
+
 Unicode should be fine too::
 
     >>> text = u"Línk tö http://foo.ni"

--- a/plone/intelligenttext/transforms.py
+++ b/plone/intelligenttext/transforms.py
@@ -92,6 +92,10 @@ class WebIntelligentToHtmlConverter(object):
             url = url[:-len('&gt;')]
             linktext = linktext[:-len('&gt;')]
             end = '&gt;'
+        elif url.endswith('.') or url.endswith('?') or url.endswith('!'):
+            end = url[-1]
+            url = url[:-1]
+            linktext = linktext[:-1]
 
         # rel="nofollow" shall avoid spamming
         return '<a href="%s" rel="nofollow">%s</a>%s' % (url, linktext, end)


### PR DESCRIPTION
URLs do not end with punctuation marks in general.
If they do, they're most probably part of a sentence.
In that case the punctuation mark needs to be split from the URL.
This allows to embed URLs in sentences without needing to add an extra
empty space after the URL before setting the punctuation mark.

To force the punctuation mark to be part of the URL, brackets can be
used (as shown in one of the tests).