### PR TITLE
Bump travis python envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,29 @@
+dist: trusty
 language: python
 sudo: false
+
 env:
-  - TOXENV=py26
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=pypy
-  - TOXENV=pypy3
+  - TOXENV=py26 PYENV_VERSION="2.6.9" PYENV_VERSION_STRING="Python 2.6.9"
+  - TOXENV=py27 PYENV_VERSION="2.7.13" PYENV_VERSION_STRING="Python 2.7.13"
+  - TOXENV=py33 PYENV_VERSION="3.3.6" PYENV_VERSION_STRING="Python 3.3.6"
+  - TOXENV=py34 PYENV_VERSION="3.4.6" PYENV_VERSION_STRING="Python 3.4.6"
+  - TOXENV=py35 PYENV_VERSION="3.5.3" PYENV_VERSION_STRING="Python 3.5.3"
+  - TOXENV=py36 PYENV_VERSION="3.6.2" PYENV_VERSION_STRING="Python 3.6.2"
+  - TOXENV=pypy PYENV_VERSION="pypy2.7-5.8.0" PYENV_VERSION_STRING="PyPy 5.8.0"
+  - TOXENV=pypy3 PYENV_VERSION="pypy3.5-5.8.0" PYENV_VERSION_STRING="PyPy 5.8.0-beta0"
+
+cache:
+  - pip
+  - directories:
+    - $HOME/.pyenv_cache
+
+before_install:
+  - |
+      if [[ -n "$PYENV_VERSION" ]]; then
+        wget https://github.com/praekeltfoundation/travis-pyenv/releases/download/0.4.0/setup-pyenv.sh
+        source setup-pyenv.sh
+      fi
+
 install: "pip install tox"
+
 script: "tox"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Use pyenv for installing python versions on Travis.
+  [Rotonen]
 
 
 2.1.0 (2015-10-27)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = 
-    py26,py27,py33,py34,py35,pypy,pypy3
+envlist =
+    py26,py27,py33,py34,py35,py36,pypy,pypy3
 
 [testenv]
-commands = 
+commands =
     python setup.py -q install
     python setup.py -q test


### PR DESCRIPTION
I've found https://github.com/praekeltfoundation/travis-pyenv to be the way to achieve a functional py2/py3/pypy/pypy3 + setuptools + pip virtualenv for tox.

This approach does bring up the build time quite a lot on the first run, but that settles down to a relatively modest penalty due to the caching over multiple builds.

Every time a Python gets bumped, this will add ~5min to the build time.

Should we also drop testing with at least 2.6 at this point?