### PR TITLE
Configuring with plone.meta

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -3,7 +3,7 @@
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "2.2.0"
+commit-id = "2.3.2.dev0"
 
 [tox]
 test_matrix = {"6.2" = ["*"]}

--- a/.meta.toml
+++ b/.meta.toml
@@ -6,4 +6,5 @@ template = "default"
 commit-id = "2.3.2.dev0"
 
 [tox]
+skip_test_extra = true
 test_matrix = {"6.2" = ["*"]}

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ envlist =
 # Add extra configuration options in .meta.toml:
 # - to specify a custom testing combination of Plone and python versions, use `test_matrix`
 #   Use ["*"] to use all supported Python versions for this Plone version.
+# - to disable the test matrix entirely, set `use_test_matrix = false`
 # - to specify extra custom environments, use `envlist_lines`
 # - to specify extra `tox` top-level options, use `config_lines`
 #  [tox]
@@ -62,6 +63,7 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
+    setuptools<82.0.0
     z3c.dependencychecker==2.14.3
 commands =
     python -m build --sdist

--- a/tox.ini
+++ b/tox.ini
@@ -126,12 +126,12 @@ deps =
 #  constraints_file = "https://my-server.com/constraints.txt"
 ##
 extras =
-    test
 
 
 ##
 # Add extra configuration options in .meta.toml:
 #  [tox]
+#  skip_test_extra = true
 #  test_extras = """
 #      tests
 #      widgets


### PR DESCRIPTION
The tests will fail due to a new version of `tox`.  I am investigating options, and will report in `plone.meta`.

